### PR TITLE
Use underscores in package.xml package name.

### DIFF
--- a/patches/package.xml
+++ b/patches/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-  <name>azure-iot-sdk-c</name>
+  <name>azure_iot_sdk_c</name>
   <version>:{version}</version>
   <description>Azure IoT C SDKs and Libraries</description>
 


### PR DESCRIPTION
Per [REP-144](https://www.ros.org/reps/rep-0144.html#mandatory-rules) ROS package names _must_ use underscores as the word separator. These underscores will be converted to dashes in package names on platforms like Ubuntu and RHEL, but the ROS package name, and subsequently the name that must be used in dependency keys of other package.xml files, must use underscores.